### PR TITLE
Fix registration of DeliveryListener

### DIFF
--- a/config/default/DeliveryListener.conf.php
+++ b/config/default/DeliveryListener.conf.php
@@ -1,0 +1,5 @@
+<?php
+
+use oat\taoSyncServer\listener\DeliveryListener;
+
+return new DeliveryListener();

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -151,10 +151,13 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         if ($this->isVersion('0.2.0')) {
-            $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
-            $eventManager->attach(DeliveryRemovedEvent::class, [DeliveryListener::class, 'deleteDeliveryAssemblyFile']);
-            $eventManager->attach(DeliveryUpdatedEvent::class, [DeliveryListener::class, 'deleteDeliveryAssemblyFile']);
-            $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+            $serviceManager = $this->getServiceManager();
+            $serviceManager->register(DeliveryListener::SERVICE_ID, new DeliveryListener());
+
+            $eventManager = $serviceManager->get(EventManager::SERVICE_ID);
+            $eventManager->attach(DeliveryRemovedEvent::class, [DeliveryListener::SERVICE_ID, 'deleteDeliveryAssemblyFile']);
+            $eventManager->attach(DeliveryUpdatedEvent::class, [DeliveryListener::SERVICE_ID, 'deleteDeliveryAssemblyFile']);
+            $serviceManager->register(EventManager::SERVICE_ID, $eventManager);
             $this->setVersion('0.3.0');
         }
     }


### PR DESCRIPTION
Fix for registration of DeliveryListener. This fix is related to PR merged few our before to fix broken process of registration of event listeners. Therefore it doesn't contain version bump. 